### PR TITLE
[Enh] Add color schemes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@catppuccin/palette": "^0.2.0",
     "@vercel/analytics": "^1.3.1",
     "gl-matrix": "^3.4.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^4.12.0",
-    "react-router-dom": "^6.23.1",
+    "react-router-dom": "^6.24.1",
     "twgl.js": "^5.5.4"
   },
   "devDependencies": {
@@ -34,11 +35,11 @@
     "@vitejs/plugin-react-swc": "^3.7.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "eslint-plugin-react-refresh": "^0.4.7",
-    "sass": "^1.77.4",
-    "typescript": "^5.4.5",
-    "vite": "^5.2.13",
-    "zer0": "github:alic3dev/zer0"
+    "eslint-plugin-react-refresh": "^0.4.8",
+    "sass": "^1.77.7",
+    "typescript": "^5.5.3",
+    "vite": "^5.3.3",
+    "zer0": "file:../zer0"
   },
-  "packageManager": "pnpm@9.1.0"
+  "packageManager": "pnpm@9.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sass": "^1.77.8",
     "typescript": "^5.5.3",
     "vite": "^5.3.3",
-    "zer0": "file:../zer0"
+    "zer0": "github:alic3dev/zer0"
   },
   "packageManager": "pnpm@9.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.8",
-    "sass": "^1.77.7",
+    "sass": "^1.77.8",
     "typescript": "^5.5.3",
     "vite": "^5.3.3",
     "zer0": "file:../zer0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3(sass@1.77.8)
       zer0:
-        specifier: file:../zer0
-        version: file:../zer0
+        specifier: github:alic3dev/zer0
+        version: https://codeload.github.com/alic3dev/zer0/tar.gz/aac1f1100ae2292adcea84c8516021e99edf9b95
 
 packages:
 
@@ -1072,8 +1072,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zer0@file:../zer0:
-    resolution: {directory: ../zer0, type: directory}
+  zer0@https://codeload.github.com/alic3dev/zer0/tar.gz/aac1f1100ae2292adcea84c8516021e99edf9b95:
+    resolution: {tarball: https://codeload.github.com/alic3dev/zer0/tar.gz/aac1f1100ae2292adcea84c8516021e99edf9b95}
+    version: 0.0.1
 
 snapshots:
 
@@ -1971,4 +1972,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zer0@file:../zer0: {}
+  zer0@https://codeload.github.com/alic3dev/zer0/tar.gz/aac1f1100ae2292adcea84c8516021e99edf9b95: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@catppuccin/palette':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@vercel/analytics':
         specifier: ^1.3.1
         version: 1.3.1(react@18.3.1)
@@ -24,8 +27,8 @@ importers:
         specifier: ^4.12.0
         version: 4.12.0(react@18.3.1)
       react-router-dom:
-        specifier: ^6.23.1
-        version: 6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^6.24.1
+        version: 6.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       twgl.js:
         specifier: ^5.5.4
         version: 5.5.4
@@ -38,13 +41,13 @@ importers:
         version: 18.3.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.21.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: ^6.21.0
-        version: 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
-        version: 3.7.0(vite@5.2.13(sass@1.77.4))
+        version: 3.7.0(vite@5.3.3(sass@1.77.7))
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -52,157 +55,160 @@ importers:
         specifier: ^4.6.2
         version: 4.6.2(eslint@8.57.0)
       eslint-plugin-react-refresh:
-        specifier: ^0.4.7
-        version: 0.4.7(eslint@8.57.0)
+        specifier: ^0.4.8
+        version: 0.4.8(eslint@8.57.0)
       sass:
-        specifier: ^1.77.4
-        version: 1.77.4
+        specifier: ^1.77.7
+        version: 1.77.7
       typescript:
-        specifier: ^5.4.5
-        version: 5.4.5
+        specifier: ^5.5.3
+        version: 5.5.3
       vite:
-        specifier: ^5.2.13
-        version: 5.2.13(sass@1.77.4)
+        specifier: ^5.3.3
+        version: 5.3.3(sass@1.77.7)
       zer0:
-        specifier: github:alic3dev/zer0
-        version: https://codeload.github.com/alic3dev/zer0/tar.gz/aac1f1100ae2292adcea84c8516021e99edf9b95
+        specifier: file:../zer0
+        version: file:../zer0
 
 packages:
 
-  '@esbuild/aix-ppc64@0.20.2':
-    resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
+  '@catppuccin/palette@0.2.0':
+    resolution: {integrity: sha512-PoAMQMEbL8fBEO80eusB+XQg+1i2kxQHw6COwBRC4bVWxWuRroZjm3K6bOdqPHNHKikDIV7wLi9hSG4NoD1FEQ==}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.20.2':
-    resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.20.2':
-    resolution: {integrity: sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==}
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.20.2':
-    resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.20.2':
-    resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.20.2':
-    resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.20.2':
-    resolution: {integrity: sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==}
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.20.2':
-    resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.20.2':
-    resolution: {integrity: sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==}
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.20.2':
-    resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.20.2':
-    resolution: {integrity: sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==}
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.20.2':
-    resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.20.2':
-    resolution: {integrity: sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==}
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.20.2':
-    resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.20.2':
-    resolution: {integrity: sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==}
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.20.2':
-    resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.20.2':
-    resolution: {integrity: sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==}
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-x64@0.20.2':
-    resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-x64@0.20.2':
-    resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.20.2':
-    resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.20.2':
-    resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.20.2':
-    resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.20.2':
-    resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -213,8 +219,8 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.10.1':
-    resolution: {integrity: sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==}
+  '@eslint-community/regexpp@4.11.0':
+    resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/eslintrc@2.1.4':
@@ -228,6 +234,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -235,6 +242,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -248,152 +256,152 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@remix-run/router@1.16.1':
-    resolution: {integrity: sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==}
+  '@remix-run/router@1.17.1':
+    resolution: {integrity: sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q==}
     engines: {node: '>=14.0.0'}
 
-  '@rollup/rollup-android-arm-eabi@4.18.0':
-    resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}
+  '@rollup/rollup-android-arm-eabi@4.18.1':
+    resolution: {integrity: sha512-lncuC4aHicncmbORnx+dUaAgzee9cm/PbIqgWz1PpXuwc+sa1Ct83tnqUDy/GFKleLiN7ZIeytM6KJ4cAn1SxA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.18.0':
-    resolution: {integrity: sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==}
+  '@rollup/rollup-android-arm64@4.18.1':
+    resolution: {integrity: sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.18.0':
-    resolution: {integrity: sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==}
+  '@rollup/rollup-darwin-arm64@4.18.1':
+    resolution: {integrity: sha512-vk+ma8iC1ebje/ahpxpnrfVQJibTMyHdWpOGZ3JpQ7Mgn/3QNHmPq7YwjZbIE7km73dH5M1e6MRRsnEBW7v5CQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.18.0':
-    resolution: {integrity: sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==}
+  '@rollup/rollup-darwin-x64@4.18.1':
+    resolution: {integrity: sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.18.0':
-    resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.18.1':
+    resolution: {integrity: sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.18.0':
-    resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
+  '@rollup/rollup-linux-arm-musleabihf@4.18.1':
+    resolution: {integrity: sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.18.0':
-    resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
+  '@rollup/rollup-linux-arm64-gnu@4.18.1':
+    resolution: {integrity: sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.18.0':
-    resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
+  '@rollup/rollup-linux-arm64-musl@4.18.1':
+    resolution: {integrity: sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
-    resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
+    resolution: {integrity: sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.18.0':
-    resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.18.1':
+    resolution: {integrity: sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.18.0':
-    resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
+  '@rollup/rollup-linux-s390x-gnu@4.18.1':
+    resolution: {integrity: sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.18.0':
-    resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
+  '@rollup/rollup-linux-x64-gnu@4.18.1':
+    resolution: {integrity: sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.18.0':
-    resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
+  '@rollup/rollup-linux-x64-musl@4.18.1':
+    resolution: {integrity: sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.18.0':
-    resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
+  '@rollup/rollup-win32-arm64-msvc@4.18.1':
+    resolution: {integrity: sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.18.0':
-    resolution: {integrity: sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==}
+  '@rollup/rollup-win32-ia32-msvc@4.18.1':
+    resolution: {integrity: sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.18.0':
-    resolution: {integrity: sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==}
+  '@rollup/rollup-win32-x64-msvc@4.18.1':
+    resolution: {integrity: sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core-darwin-arm64@1.5.25':
-    resolution: {integrity: sha512-YbD0SBgVJS2DM0vwJTU5m7+wOyCjHPBDMf3nCBJQzFZzOLzK11eRW7SzU2jhJHr9HI9sKcNFfN4lIC2Sj+4inA==}
+  '@swc/core-darwin-arm64@1.6.13':
+    resolution: {integrity: sha512-SOF4buAis72K22BGJ3N8y88mLNfxLNprTuJUpzikyMGrvkuBFNcxYtMhmomO0XHsgLDzOJ+hWzcgjRNzjMsUcQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.5.25':
-    resolution: {integrity: sha512-OhP4TROT6gQuozn+ah0Y4UidSdgDmxwtQq3lgCUIAxJYErJAQ82/Y0kve2UaNmkSGjOHU+/b4siHPrYTkXOk0Q==}
+  '@swc/core-darwin-x64@1.6.13':
+    resolution: {integrity: sha512-AW8akFSC+tmPE6YQQvK9S2A1B8pjnXEINg+gGgw0KRUUXunvu1/OEOeC5L2Co1wAwhD7bhnaefi06Qi9AiwOag==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.5.25':
-    resolution: {integrity: sha512-tNmUfrAHxN2gvYPyYNnHx2CYlPO7DGAUuK/bZrqawu++djcg+atAV3eI3XYJgmHId7/sYAlDQ9wjkrOLofFjVg==}
+  '@swc/core-linux-arm-gnueabihf@1.6.13':
+    resolution: {integrity: sha512-f4gxxvDXVUm2HLYXRd311mSrmbpQF2MZ4Ja6XCQz1hWAxXdhRl1gpnZ+LH/xIfGSwQChrtLLVrkxdYUCVuIjFg==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.5.25':
-    resolution: {integrity: sha512-stzpke+bRaNFM/HrZPRjX0aQZ86S/2DChVCwb8NAV1n5lu9mz1CS750y7WbbtX/KZjk92FsCeRy2qwkvjI0gWw==}
+  '@swc/core-linux-arm64-gnu@1.6.13':
+    resolution: {integrity: sha512-Nf/eoW2CbG8s+9JoLtjl9FByBXyQ5cjdBsA4efO7Zw4p+YSuXDgc8HRPC+E2+ns0praDpKNZtLvDtmF2lL+2Gg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-musl@1.5.25':
-    resolution: {integrity: sha512-UckUfDYedish/bj2V1jgQDGgouLhyRpG7jgF3mp8jHir11V2K6JiTyjFoz99eOiclS3+hNdr4QLJ+ifrQMJNZw==}
+  '@swc/core-linux-arm64-musl@1.6.13':
+    resolution: {integrity: sha512-2OysYSYtdw79prJYuKIiux/Gj0iaGEbpS2QZWCIY4X9sGoETJ5iMg+lY+YCrIxdkkNYd7OhIbXdYFyGs/w5LDg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.5.25':
-    resolution: {integrity: sha512-LwbJEgNT3lXbvz4WFzVNXNvs8DvxpoXjMZk9K9Hig8tmZQJKHC2qZTGomcyK5EFzfj2HBuBXZnAEW8ZT9PcEaA==}
+  '@swc/core-linux-x64-gnu@1.6.13':
+    resolution: {integrity: sha512-PkR4CZYJNk5hcd2+tMWBpnisnmYsUzazI1O5X7VkIGFcGePTqJ/bWlfUIVVExWxvAI33PQFzLbzmN5scyIUyGQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-musl@1.5.25':
-    resolution: {integrity: sha512-rsepMTgml0EkswWkBpg3Wrjj5eqjwTzZN5omAn1klzXSZnClTrfeHvBuoIJYVr1yx+jmBkqySgME2p7+magUAw==}
+  '@swc/core-linux-x64-musl@1.6.13':
+    resolution: {integrity: sha512-OdsY7wryTxCKwGQcwW9jwWg3cxaHBkTTHi91+5nm7hFPpmZMz1HivJrWAMwVE7iXFw+M4l6ugB/wCvpYrUAAjA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-win32-arm64-msvc@1.5.25':
-    resolution: {integrity: sha512-DJDsLBsRBV3uQBShRK2x6fqzABp9RLNVxDUpTTvUjc7qywJ8vS/yn+POK/zCyVEqLagf1z/8D5CEQ+RAIJq1NA==}
+  '@swc/core-win32-arm64-msvc@1.6.13':
+    resolution: {integrity: sha512-ap6uNmYjwk9M/+bFEuWRNl3hq4VqgQ/Lk+ID/F5WGqczNr0L7vEf+pOsRAn0F6EV+o/nyb3ePt8rLhE/wjHpPg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.5.25':
-    resolution: {integrity: sha512-BARL1ulHol53MEKC1ZVWM3A3FP757UUgG5Q8v97za+4a1SaIgbwvAQyHDxMYWi9+ij+OapK8YnWjJcFa17g8dw==}
+  '@swc/core-win32-ia32-msvc@1.6.13':
+    resolution: {integrity: sha512-IJ8KH4yIUHTnS/U1jwQmtbfQals7zWPG0a9hbEfIr4zI0yKzjd83lmtS09lm2Q24QBWOCFGEEbuZxR4tIlvfzA==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.5.25':
-    resolution: {integrity: sha512-o+MHUWrQI9iR6EusEV8eNU2Ezi3KtlhUR4gfptQN5MbVzlgjTvQbhiKpE1GYOxp+0BLBbKRwITKOcdhxfEJ2Uw==}
+  '@swc/core-win32-x64-msvc@1.6.13':
+    resolution: {integrity: sha512-f6/sx6LMuEnbuxtiSL/EkR0Y6qUHFw1XVrh6rwzKXptTipUdOY+nXpKoh+1UsBm/r7H0/5DtOdrn3q5ZHbFZjQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.5.25':
-    resolution: {integrity: sha512-qdGEIdLVoTjEQ7w72UyyQ0wLFY4XbHfZiidmPHKJQsvSXzdpHXxPdlTCea/mY4AhMqo/M+pvkJSXJAxZnFl7qw==}
+  '@swc/core@1.6.13':
+    resolution: {integrity: sha512-eailUYex6fkfaQTev4Oa3mwn0/e3mQU4H8y1WPuImYQESOQDtVrowwUGDSc19evpBbHpKtwM+hw8nLlhIsF+Tw==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '*'
@@ -404,8 +412,8 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/types@0.1.7':
-    resolution: {integrity: sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==}
+  '@swc/types@0.1.9':
+    resolution: {integrity: sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -507,8 +515,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+  acorn@8.12.1:
+    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -600,8 +608,8 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
-  esbuild@0.20.2:
-    resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -615,8 +623,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
 
-  eslint-plugin-react-refresh@0.4.7:
-    resolution: {integrity: sha512-yrj+KInFmwuQS2UQcg1SF83ha1tuHC1jMQbRNyuWtlEzzKRDgAl7L4Yp4NlDUZTZNlWvHEzOtJhMi40R7JxcSw==}
+  eslint-plugin-react-refresh@0.4.8:
+    resolution: {integrity: sha512-MIKAclwaDFIiYtVBLzDdm16E+Ty4GwhB6wZlCAG1R3Ur+F9Qbo6PRxpA5DK7XtDgm+WlCoAY2WxAwqhmIDHg6Q==}
     peerDependencies:
       eslint: '>=7'
 
@@ -637,8 +645,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  esquery@1.5.0:
-    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -877,8 +885,8 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  postcss@8.4.38:
-    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+  postcss@8.4.39:
+    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -902,15 +910,15 @@ packages:
     peerDependencies:
       react: '*'
 
-  react-router-dom@6.23.1:
-    resolution: {integrity: sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==}
+  react-router-dom@6.24.1:
+    resolution: {integrity: sha512-U19KtXqooqw967Vw0Qcn5cOvrX5Ejo9ORmOtJMzYWtCT4/WOfFLIZGGsVLxcd9UkBO0mSTZtXqhZBsWlHr7+Sg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.23.1:
-    resolution: {integrity: sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==}
+  react-router@6.24.1:
+    resolution: {integrity: sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -936,16 +944,16 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rollup@4.18.0:
-    resolution: {integrity: sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==}
+  rollup@4.18.1:
+    resolution: {integrity: sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  sass@1.77.4:
-    resolution: {integrity: sha512-vcF3Ckow6g939GMA4PeU7b2K/9FALXk2KF9J87txdHzXbUF9XRQRwSxcAs/fGaTnJeBFd7UoV22j3lzMLdM0Pw==}
+  sass@1.77.7:
+    resolution: {integrity: sha512-9ywH75cO+rLjbrZ6en3Gp8qAMwPGBapFtlsMJoDTkcMU/bSe5a6cjKVUn5Jr4Gzg5GbP3HE8cm+02pLCgcoMow==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -1012,16 +1020,16 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.5.3:
+    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  vite@5.2.13:
-    resolution: {integrity: sha512-SSq1noJfY9pR3I1TUENL3rQYDQCFqgD+lM6fTRAM8Nv6Lsg5hDLaXkjETVeBt+7vZBCMoibD+6IWnT2mJ+Zb/A==}
+  vite@5.3.3:
+    resolution: {integrity: sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -1064,79 +1072,80 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zer0@https://codeload.github.com/alic3dev/zer0/tar.gz/aac1f1100ae2292adcea84c8516021e99edf9b95:
-    resolution: {tarball: https://codeload.github.com/alic3dev/zer0/tar.gz/aac1f1100ae2292adcea84c8516021e99edf9b95}
-    version: 0.0.1
+  zer0@file:../zer0:
+    resolution: {directory: ../zer0, type: directory}
 
 snapshots:
 
-  '@esbuild/aix-ppc64@0.20.2':
+  '@catppuccin/palette@0.2.0': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
-  '@esbuild/android-arm64@0.20.2':
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
-  '@esbuild/android-arm@0.20.2':
+  '@esbuild/android-arm@0.21.5':
     optional: true
 
-  '@esbuild/android-x64@0.20.2':
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.20.2':
+  '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.20.2':
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.20.2':
+  '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.20.2':
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.20.2':
+  '@esbuild/linux-arm64@0.21.5':
     optional: true
 
-  '@esbuild/linux-arm@0.20.2':
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.20.2':
+  '@esbuild/linux-ia32@0.21.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.20.2':
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.20.2':
+  '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.20.2':
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.20.2':
+  '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.20.2':
+  '@esbuild/linux-s390x@0.21.5':
     optional: true
 
-  '@esbuild/linux-x64@0.20.2':
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
-  '@esbuild/netbsd-x64@0.20.2':
+  '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.20.2':
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.20.2':
+  '@esbuild/sunos-x64@0.21.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.20.2':
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.20.2':
+  '@esbuild/win32-ia32@0.21.5':
     optional: true
 
-  '@esbuild/win32-x64@0.20.2':
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -1144,7 +1153,7 @@ snapshots:
       eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.10.1': {}
+  '@eslint-community/regexpp@4.11.0': {}
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -1186,105 +1195,105 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@remix-run/router@1.16.1': {}
+  '@remix-run/router@1.17.1': {}
 
-  '@rollup/rollup-android-arm-eabi@4.18.0':
+  '@rollup/rollup-android-arm-eabi@4.18.1':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.18.0':
+  '@rollup/rollup-android-arm64@4.18.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.18.0':
+  '@rollup/rollup-darwin-arm64@4.18.1':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.18.0':
+  '@rollup/rollup-darwin-x64@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.18.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.18.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.18.0':
+  '@rollup/rollup-linux-arm64-gnu@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.18.0':
+  '@rollup/rollup-linux-arm64-musl@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.18.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.18.0':
+  '@rollup/rollup-linux-s390x-gnu@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.18.0':
+  '@rollup/rollup-linux-x64-gnu@4.18.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.18.0':
+  '@rollup/rollup-linux-x64-musl@4.18.1':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.18.0':
+  '@rollup/rollup-win32-arm64-msvc@4.18.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.18.0':
+  '@rollup/rollup-win32-ia32-msvc@4.18.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.18.0':
+  '@rollup/rollup-win32-x64-msvc@4.18.1':
     optional: true
 
-  '@swc/core-darwin-arm64@1.5.25':
+  '@swc/core-darwin-arm64@1.6.13':
     optional: true
 
-  '@swc/core-darwin-x64@1.5.25':
+  '@swc/core-darwin-x64@1.6.13':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.5.25':
+  '@swc/core-linux-arm-gnueabihf@1.6.13':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.5.25':
+  '@swc/core-linux-arm64-gnu@1.6.13':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.5.25':
+  '@swc/core-linux-arm64-musl@1.6.13':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.5.25':
+  '@swc/core-linux-x64-gnu@1.6.13':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.5.25':
+  '@swc/core-linux-x64-musl@1.6.13':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.5.25':
+  '@swc/core-win32-arm64-msvc@1.6.13':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.5.25':
+  '@swc/core-win32-ia32-msvc@1.6.13':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.5.25':
+  '@swc/core-win32-x64-msvc@1.6.13':
     optional: true
 
-  '@swc/core@1.5.25':
+  '@swc/core@1.6.13':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.7
+      '@swc/types': 0.1.9
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.5.25
-      '@swc/core-darwin-x64': 1.5.25
-      '@swc/core-linux-arm-gnueabihf': 1.5.25
-      '@swc/core-linux-arm64-gnu': 1.5.25
-      '@swc/core-linux-arm64-musl': 1.5.25
-      '@swc/core-linux-x64-gnu': 1.5.25
-      '@swc/core-linux-x64-musl': 1.5.25
-      '@swc/core-win32-arm64-msvc': 1.5.25
-      '@swc/core-win32-ia32-msvc': 1.5.25
-      '@swc/core-win32-x64-msvc': 1.5.25
+      '@swc/core-darwin-arm64': 1.6.13
+      '@swc/core-darwin-x64': 1.6.13
+      '@swc/core-linux-arm-gnueabihf': 1.6.13
+      '@swc/core-linux-arm64-gnu': 1.6.13
+      '@swc/core-linux-arm64-musl': 1.6.13
+      '@swc/core-linux-x64-gnu': 1.6.13
+      '@swc/core-linux-x64-musl': 1.6.13
+      '@swc/core-win32-arm64-msvc': 1.6.13
+      '@swc/core-win32-ia32-msvc': 1.6.13
+      '@swc/core-win32-x64-msvc': 1.6.13
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/types@0.1.7':
+  '@swc/types@0.1.9':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -1305,13 +1314,13 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
-      '@eslint-community/regexpp': 4.10.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      '@eslint-community/regexpp': 4.11.0
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.5
       eslint: 8.57.0
@@ -1319,22 +1328,22 @@ snapshots:
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.5
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1343,21 +1352,21 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       debug: 4.3.5
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@6.21.0': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -1366,20 +1375,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.3)
       eslint: 8.57.0
       semver: 7.6.2
     transitivePeerDependencies:
@@ -1399,18 +1408,18 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@vitejs/plugin-react-swc@3.7.0(vite@5.2.13(sass@1.77.4))':
+  '@vitejs/plugin-react-swc@3.7.0(vite@5.3.3(sass@1.77.7))':
     dependencies:
-      '@swc/core': 1.5.25
-      vite: 5.2.13(sass@1.77.4)
+      '@swc/core': 1.6.13
+      vite: 5.3.3(sass@1.77.7)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  acorn-jsx@5.3.2(acorn@8.11.3):
+  acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.12.1
 
-  acorn@8.11.3: {}
+  acorn@8.12.1: {}
 
   ajv@6.12.6:
     dependencies:
@@ -1500,31 +1509,31 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  esbuild@0.20.2:
+  esbuild@0.21.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.20.2
-      '@esbuild/android-arm': 0.20.2
-      '@esbuild/android-arm64': 0.20.2
-      '@esbuild/android-x64': 0.20.2
-      '@esbuild/darwin-arm64': 0.20.2
-      '@esbuild/darwin-x64': 0.20.2
-      '@esbuild/freebsd-arm64': 0.20.2
-      '@esbuild/freebsd-x64': 0.20.2
-      '@esbuild/linux-arm': 0.20.2
-      '@esbuild/linux-arm64': 0.20.2
-      '@esbuild/linux-ia32': 0.20.2
-      '@esbuild/linux-loong64': 0.20.2
-      '@esbuild/linux-mips64el': 0.20.2
-      '@esbuild/linux-ppc64': 0.20.2
-      '@esbuild/linux-riscv64': 0.20.2
-      '@esbuild/linux-s390x': 0.20.2
-      '@esbuild/linux-x64': 0.20.2
-      '@esbuild/netbsd-x64': 0.20.2
-      '@esbuild/openbsd-x64': 0.20.2
-      '@esbuild/sunos-x64': 0.20.2
-      '@esbuild/win32-arm64': 0.20.2
-      '@esbuild/win32-ia32': 0.20.2
-      '@esbuild/win32-x64': 0.20.2
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   escape-string-regexp@4.0.0: {}
 
@@ -1532,7 +1541,7 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-react-refresh@0.4.7(eslint@8.57.0):
+  eslint-plugin-react-refresh@0.4.8(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
 
@@ -1546,7 +1555,7 @@ snapshots:
   eslint@8.57.0:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@eslint-community/regexpp': 4.10.1
+      '@eslint-community/regexpp': 4.11.0
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.0
       '@humanwhocodes/config-array': 0.11.14
@@ -1562,7 +1571,7 @@ snapshots:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
-      esquery: 1.5.0
+      esquery: 1.6.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
@@ -1588,11 +1597,11 @@ snapshots:
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
+      acorn: 8.12.1
+      acorn-jsx: 5.3.2(acorn@8.12.1)
       eslint-visitor-keys: 3.4.3
 
-  esquery@1.5.0:
+  esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -1809,7 +1818,7 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  postcss@8.4.38:
+  postcss@8.4.39:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.1
@@ -1831,16 +1840,16 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-router-dom@6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.16.1
+      '@remix-run/router': 1.17.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.23.1(react@18.3.1)
+      react-router: 6.24.1(react@18.3.1)
 
-  react-router@6.23.1(react@18.3.1):
+  react-router@6.24.1(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.16.1
+      '@remix-run/router': 1.17.1
       react: 18.3.1
 
   react@18.3.1:
@@ -1859,33 +1868,33 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup@4.18.0:
+  rollup@4.18.1:
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.18.0
-      '@rollup/rollup-android-arm64': 4.18.0
-      '@rollup/rollup-darwin-arm64': 4.18.0
-      '@rollup/rollup-darwin-x64': 4.18.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.18.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.18.0
-      '@rollup/rollup-linux-arm64-gnu': 4.18.0
-      '@rollup/rollup-linux-arm64-musl': 4.18.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.18.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.18.0
-      '@rollup/rollup-linux-s390x-gnu': 4.18.0
-      '@rollup/rollup-linux-x64-gnu': 4.18.0
-      '@rollup/rollup-linux-x64-musl': 4.18.0
-      '@rollup/rollup-win32-arm64-msvc': 4.18.0
-      '@rollup/rollup-win32-ia32-msvc': 4.18.0
-      '@rollup/rollup-win32-x64-msvc': 4.18.0
+      '@rollup/rollup-android-arm-eabi': 4.18.1
+      '@rollup/rollup-android-arm64': 4.18.1
+      '@rollup/rollup-darwin-arm64': 4.18.1
+      '@rollup/rollup-darwin-x64': 4.18.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.18.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.18.1
+      '@rollup/rollup-linux-arm64-gnu': 4.18.1
+      '@rollup/rollup-linux-arm64-musl': 4.18.1
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.18.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.18.1
+      '@rollup/rollup-linux-s390x-gnu': 4.18.1
+      '@rollup/rollup-linux-x64-gnu': 4.18.1
+      '@rollup/rollup-linux-x64-musl': 4.18.1
+      '@rollup/rollup-win32-arm64-msvc': 4.18.1
+      '@rollup/rollup-win32-ia32-msvc': 4.18.1
+      '@rollup/rollup-win32-x64-msvc': 4.18.1
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
-  sass@1.77.4:
+  sass@1.77.7:
     dependencies:
       chokidar: 3.6.0
       immutable: 4.3.6
@@ -1925,9 +1934,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@1.3.0(typescript@5.4.5):
+  ts-api-utils@1.3.0(typescript@5.5.3):
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.5.3
 
   twgl.js@5.5.4: {}
 
@@ -1937,20 +1946,20 @@ snapshots:
 
   type-fest@0.20.2: {}
 
-  typescript@5.4.5: {}
+  typescript@5.5.3: {}
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  vite@5.2.13(sass@1.77.4):
+  vite@5.3.3(sass@1.77.7):
     dependencies:
-      esbuild: 0.20.2
-      postcss: 8.4.38
-      rollup: 4.18.0
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.18.1
     optionalDependencies:
       fsevents: 2.3.3
-      sass: 1.77.4
+      sass: 1.77.7
 
   which@2.0.2:
     dependencies:
@@ -1962,4 +1971,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zer0@https://codeload.github.com/alic3dev/zer0/tar.gz/aac1f1100ae2292adcea84c8516021e99edf9b95: {}
+  zer0@file:../zer0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
-        version: 3.7.0(vite@5.3.3(sass@1.77.7))
+        version: 3.7.0(vite@5.3.3(sass@1.77.8))
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -58,14 +58,14 @@ importers:
         specifier: ^0.4.8
         version: 0.4.8(eslint@8.57.0)
       sass:
-        specifier: ^1.77.7
-        version: 1.77.7
+        specifier: ^1.77.8
+        version: 1.77.8
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
       vite:
         specifier: ^5.3.3
-        version: 5.3.3(sass@1.77.7)
+        version: 5.3.3(sass@1.77.8)
       zer0:
         specifier: file:../zer0
         version: file:../zer0
@@ -952,8 +952,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  sass@1.77.7:
-    resolution: {integrity: sha512-9ywH75cO+rLjbrZ6en3Gp8qAMwPGBapFtlsMJoDTkcMU/bSe5a6cjKVUn5Jr4Gzg5GbP3HE8cm+02pLCgcoMow==}
+  sass@1.77.8:
+    resolution: {integrity: sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -1408,10 +1408,10 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  '@vitejs/plugin-react-swc@3.7.0(vite@5.3.3(sass@1.77.7))':
+  '@vitejs/plugin-react-swc@3.7.0(vite@5.3.3(sass@1.77.8))':
     dependencies:
       '@swc/core': 1.6.13
-      vite: 5.3.3(sass@1.77.7)
+      vite: 5.3.3(sass@1.77.8)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -1894,7 +1894,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  sass@1.77.7:
+  sass@1.77.8:
     dependencies:
       chokidar: 3.6.0
       immutable: 4.3.6
@@ -1952,14 +1952,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@5.3.3(sass@1.77.7):
+  vite@5.3.3(sass@1.77.8):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.39
       rollup: 4.18.1
     optionalDependencies:
       fsevents: 2.3.3
-      sass: 1.77.7
+      sass: 1.77.8
 
   which@2.0.2:
     dependencies:

--- a/src/components/apps/CanviApp.module.scss
+++ b/src/components/apps/CanviApp.module.scss
@@ -2,7 +2,7 @@
   width: 100%;
   height: 100%;
 
-  background-color: #000;
+  background-color: var(--color-black);
 }
 
 .canvas {
@@ -11,7 +11,7 @@
 
   object-fit: contain;
 
-  background-color: #000;
+  background-color: var(--color-black);
 
   transform: scaleY(0.1);
 }

--- a/src/components/apps/CircleApp.module.scss
+++ b/src/components/apps/CircleApp.module.scss
@@ -3,7 +3,7 @@
   min-width: 100%;
   min-height: 100%;
 
-  background: #000;
+  background: var(--color-black);
 
   overflow: hidden;
 }
@@ -91,10 +91,10 @@
   justify-content: center;
   align-items: center;
 
-  background: #000;
+  background: var(--color-black);
 
   font-size: 4rem;
-  color: #fff;
+  color: var(--color-white);
 
   transition: all ease-in-out 5000ms;
 

--- a/src/components/apps/DimenApp.module.scss
+++ b/src/components/apps/DimenApp.module.scss
@@ -21,7 +21,7 @@
   right: 0;
   bottom: 0;
 
-  color: #fff;
+  color: var(--color-white);
 
   font-size: 0.75rem;
 
@@ -32,8 +32,6 @@
 }
 
 .key-hint {
-  // color: #cc0;
-
   font-weight: 700;
 }
 
@@ -85,10 +83,10 @@
     left: 50%;
     top: 50%;
 
-    background: #333;
-    border: 1px solid #fff;
+    background: var(--color-crust);
+    border: 1px solid var(--color-white);
 
-    box-shadow: 1rem 1rem 0px 0px rgba(0, 0, 0, 0.5);
+    box-shadow: 1rem 1rem 0px 0px rgba(var(--color-black-raw), 0.5);
 
     transform: translate(-50%, -50%);
 
@@ -100,7 +98,7 @@
       margin: 0 auto;
       padding: 0 2rem;
 
-      background: #333;
+      background: var(--color-crust);
 
       z-index: 2;
 
@@ -113,7 +111,7 @@
 
         height: 1px;
 
-        background: #fff;
+        background: var(--color-white);
 
         z-index: -1;
       }

--- a/src/components/apps/NavigationApp.module.scss
+++ b/src/components/apps/NavigationApp.module.scss
@@ -16,15 +16,15 @@
 
   background-image: radial-gradient(
     farthest-corner at 20% 30%,
-    #02c475,
-    #0284b5
+    var(--color-green),
+    var(--color-blue)
   );
   background-size: 100%;
   background-clip: text;
   color: transparent;
   -webkit-text-fill-color: transparent;
 
-  text-shadow: 0px 0px 1rem rgba(0, 0, 0, 0.25);
+  text-shadow: 0px 0px 1rem rgba(var(--color-black-raw), 0.25);
 }
 
 .navigation-wrapper {
@@ -44,7 +44,7 @@
     margin: 0.5em;
 
     font-weight: 700;
-    color: #02b4a5;
+    color: var(--color-blue);
     text-decoration: none;
   }
 }

--- a/src/components/apps/NoiseApp.module.scss
+++ b/src/components/apps/NoiseApp.module.scss
@@ -5,7 +5,7 @@
   min-height: 100%;
   min-width: 100%;
 
-  background: #111;
+  background: var(--color-crust);
 }
 
 .main {

--- a/src/components/apps/NoiseApp.module.scss
+++ b/src/components/apps/NoiseApp.module.scss
@@ -5,7 +5,7 @@
   min-height: 100%;
   min-width: 100%;
 
-  background: var(--color-crust);
+  background: var(--color-base);
 }
 
 .main {

--- a/src/components/apps/NoiseApp.tsx
+++ b/src/components/apps/NoiseApp.tsx
@@ -1,6 +1,10 @@
+import type { ColorScheme } from '../../contexts/ColorSchemeContext'
+
 import React from 'react'
 
 import { Channel, Noise } from 'zer0'
+
+import { ColorSchemeContext } from '../../contexts/ColorSchemeContext'
 
 import styles from './NoiseApp.module.scss'
 
@@ -79,6 +83,8 @@ export function NoiseApp() {
   const audioRef = React.useRef<AudioRef>(getDefaultAudioRef())
   const canvasRef = React.useRef<HTMLCanvasElement>(null)
 
+  const colorScheme = React.useContext<ColorScheme>(ColorSchemeContext)
+
   React.useEffect((): (() => void) => {
     const gain = audioRef.current.gain
     gain.gain.value = 1 / 6
@@ -117,7 +123,7 @@ export function NoiseApp() {
       oddFrame = !oddFrame
       lastTime = time
 
-      ctx.fillStyle = '#11111166'
+      ctx.fillStyle = colorScheme.base
       ctx.fillRect(0, 0, VIDEO_RESOLUTION.x, VIDEO_RESOLUTION.y)
 
       const analyserData: Uint8Array = audioRef.current.channel.pollAnalyser()
@@ -156,18 +162,16 @@ export function NoiseApp() {
       const yAvg: number = Math.round(ySum / analyserData.length)
 
       if (yAvg === 111 || yAvg === 333 || yAvg === 666 || yAvg === 999) {
-        ctx.strokeStyle = '#ba2323'
+        ctx.strokeStyle = colorScheme.red
       } else if (yAvg === 777) {
-        ctx.strokeStyle = '#baba23'
+        ctx.strokeStyle = colorScheme.yellow
       } else if (oddFrame) {
-        ctx.strokeStyle = '#23ba10'
+        ctx.strokeStyle = colorScheme.green
       } else {
-        ctx.strokeStyle = '#1023ba'
+        ctx.strokeStyle = colorScheme.blue
       }
 
       ctx.stroke()
-      ctx.fillStyle = '#23baba02'
-      ctx.fill()
 
       analyserVisualizationHandle = window.requestAnimationFrame(
         analyserVisualizationFrame,
@@ -182,7 +186,7 @@ export function NoiseApp() {
       window.clearInterval(pannerInterval)
       window.cancelAnimationFrame(analyserVisualizationHandle)
     }
-  }, [])
+  }, [colorScheme])
 
   return (
     <div className={styles.app}>

--- a/src/components/apps/VisdioApp.module.scss
+++ b/src/components/apps/VisdioApp.module.scss
@@ -4,5 +4,5 @@
   justify-content: center;
   height: 100%;
 
-  background-color: #000;
+  background-color: var(--color-black);
 }

--- a/src/components/apps/Zer0OldApp.module.scss
+++ b/src/components/apps/Zer0OldApp.module.scss
@@ -7,14 +7,14 @@
   min-width: 100%;
   min-height: 100%;
 
-  background-color: #000;
+  background-color: var(--color-black);
 }
 
 h1 {
   font-size: 4rem;
 
-  color: #000;
-  text-shadow: 0px 0px 1px #fff;
+  color: var(--color-black);
+  text-shadow: 0px 0px 1px var(--color-white);
 }
 
 .frequencies {

--- a/src/components/daw/Bar.module.scss
+++ b/src/components/daw/Bar.module.scss
@@ -7,7 +7,7 @@
 .title {
   min-width: 0px;
 
-  color: #555;
+  color: var(--color-subtext0);
 
   font-size: 0.75rem;
 
@@ -19,12 +19,4 @@
 
 .controls {
   margin-bottom: 0.25rem;
-
-  label {
-    input,
-    select {
-      border: 1px solid rgba(0, 0, 0, 0.125);
-      border-radius: 5px;
-    }
-  }
 }

--- a/src/components/daw/Beat.module.scss
+++ b/src/components/daw/Beat.module.scss
@@ -1,22 +1,20 @@
 .beat {
   display: flex;
 
-  background: rgba(255, 255, 255, 0);
+  background: var(--color-mantle);
+
+  padding-bottom: 1px;
 
   transition: all 0s 0s ease-in-out;
 
-  &.active {
-    background: rgba(255, 255, 255, 0.1);
+  &:last-of-type {
+    padding-bottom: 0px;
   }
 }
 
 .poly {
   flex: 1;
   display: flex;
-
-  &:nth-child(even) {
-    background-color: rgba(0, 0, 0, 0.2);
-  }
 }
 
 .note {
@@ -24,17 +22,22 @@
   min-height: 2rem;
 
   padding: 0.25rem;
+  margin-right: 1px;
 
-  border: 1px solid rgba(0, 0, 0, 0.25);
-  border-left-color: transparent;
-  border-bottom-color: transparent;
-  border-radius: 10px;
+  border: none;
+  border-radius: 0px;
 
   flex: 1;
 
   text-align: center;
+}
 
-  &:last-of-type {
-    border-right-color: transparent;
+.poly:last-of-type {
+  .note {
+    margin-right: 0px;
   }
+}
+
+.beat.active .note {
+  background: var(--color-mantle);
 }

--- a/src/components/daw/ChannelList.module.scss
+++ b/src/components/daw/ChannelList.module.scss
@@ -1,6 +1,8 @@
 .channel-list {
   display: flex;
   flex-direction: column;
+
+  padding-top: 1rem;
 }
 
 .controls {
@@ -17,10 +19,6 @@
 
   padding: 1rem;
   padding-top: 0.5rem;
-
-  &:nth-child(odd) {
-    background: rgba(0, 0, 0, 0.05);
-  }
 
   label {
     display: flex;
@@ -43,6 +41,7 @@
   cursor: pointer;
 
   &:hover {
+    background: none;
     box-shadow: none;
   }
 }
@@ -78,17 +77,17 @@
 .gain-display-wrapper {
   width: 100%;
 
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(var(--color-black-raw), 0.1);
 
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(var(--color-black-raw), 0.1);
   border-radius: 5px;
 }
 
 .gain-display {
   height: 6px;
   width: 100%;
-  background: linear-gradient(to right, #000, #000);
+  background: linear-gradient(to right, var(--color-black), var(--color-black));
 
-  border: 1px solid #000;
+  border: 1px solid var(--color-black);
   border-radius: 5px;
 }

--- a/src/components/daw/Header.module.scss
+++ b/src/components/daw/Header.module.scss
@@ -5,8 +5,7 @@
 
   padding: 0.5rem 1rem;
 
-  background: rgba(0, 0, 0, 0.1);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  background: var(--color-base);
 }
 
 .project-controls {
@@ -32,31 +31,32 @@
   border: none;
 
   &:hover {
+    background: none;
     box-shadow: none;
   }
 }
 
 .project-control-save {
   &:hover {
-    color: #0e0;
+    color: var(--color-green);
   }
 }
 
 .project-control-open {
   &:hover {
-    color: #ee0;
+    color: var(--color-yellow);
   }
 }
 
 .project-control-new {
   &:hover {
-    color: #0ee;
+    color: var(--color-sky);
   }
 }
 
 .project-control-settings {
   &:hover {
-    color: #eee;
+    color: var(--color-subtext0);
   }
 }
 
@@ -71,11 +71,18 @@
   height: 100%;
   width: 100px;
 
-  background: rgba(0, 0, 0, 0.1);
+  & > svg {
+    stroke-width: 1px;
+  }
 
   &:hover {
     box-shadow: none;
   }
+}
+
+.reset,
+.bpm {
+  border-radius: 0px;
 }
 
 .bpm-wrapper {
@@ -88,8 +95,6 @@
   left: 0.75rem;
   top: 50%;
 
-  color: rgba(255, 255, 255, 0.3);
-
   font-size: 0.75rem;
 
   pointer-events: none;
@@ -98,11 +103,21 @@
 }
 
 .bpm {
+  border-left-width: 0.5px;
+  border-right-width: 0.5px;
+
   text-align: right;
 }
 
+.play,
+.stop {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+  border-right-width: 0.5px;
+}
+
 .play {
-  color: #6e6;
+  color: var(--color-green);
 
   &:hover,
   &:focus-visible {
@@ -111,7 +126,7 @@
 }
 
 .stop {
-  color: #e66;
+  color: var(--color-red);
 
   &:hover,
   &:focus-visible {
@@ -120,7 +135,10 @@
 }
 
 .reset {
-  color: #ee6;
+  color: var(--color-yellow);
+
+  border-left-width: 0.5px;
+  border-right-width: 0.5px;
 
   &:hover,
   &:focus-visible {
@@ -154,16 +172,16 @@ input.project-title {
 
   text-overflow: ellipsis;
 
-  background-color: rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 5px 0px rgba(0, 255, 255, 0);
+  background-color: rgba(var(--color-black-raw), 0);
+  box-shadow: 0px 0px 5px 0px rgba(var(--color-white-raw), 0);
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.025);
-    box-shadow: 0px 0px 5px 0px rgba(0, 255, 255, 0.025);
+    background-color: rgba(var(--color-black-raw), 0.025);
+    box-shadow: 0px 0px 5px 0px rgba(var(--color-white-raw), 0.025);
   }
 
   &:focus-visible {
-    background-color: rgba(0, 0, 0, 0.05);
-    box-shadow: 0px 0px 5px 0px rgba(0, 255, 255, 0.05);
+    background-color: rgba(var(--color-black-raw), 0.05);
+    box-shadow: 0px 0px 5px 0px rgba(var(--color-white-raw), 0.05);
   }
 }

--- a/src/components/daw/Interface.module.scss
+++ b/src/components/daw/Interface.module.scss
@@ -7,71 +7,14 @@
 
   background: radial-gradient(
     farthest-corner at -50% 0%,
-    #1e1b29 0%,
-    #1b1c22 50%,
-    #1d1b28 100%
+    var(--color-base) 0%,
+    var(--color-base) 50%,
+    var(--color-base) 100%
   );
 
   &,
   * {
     user-select: none;
-  }
-
-  & select,
-  & input,
-  & button {
-    border-radius: 0;
-
-    // &[type='range'] {
-    //   appearance: none;
-    //   background: none;
-    //   border: none;
-
-    //   &:active,
-    //   &:hover {
-    //     box-shadow: none;
-    //   }
-
-    //   &::-webkit-slider-runnable-track {
-    //     appearance: none;
-
-    //     height: 0.5em;
-    //     width: 100%;
-
-    //     background: rgba(0, 0, 0, 0.1);
-
-    //     border: 1px solid rgba(0, 0, 0, 0.25);
-    //     border-radius: 100px;
-    //   }
-
-    //   &::-webkit-slider-thumb {
-    //     position: relative;
-
-    //     appearance: none;
-    //     overflow: visible;
-
-    //     background: #684fc4;
-
-    //     &::before {
-    //       position: absolute;
-    //       left: 100%;
-
-    //       border-radius: 100%;
-
-    //       margin-top: calc(-0.25em - 1px);
-
-    //       height: 1em;
-    //       width: 1em;
-
-    //       background: #684fc4;
-    //     }
-    //   }
-    // }
-
-    &:focus-visible {
-      border-color: #684fc4;
-      outline: none;
-    }
   }
 }
 
@@ -93,8 +36,6 @@
   height: 100%;
   max-width: 100%;
 
-  box-shadow: inset -3px 3px 3px rgba(0, 0, 0, 0.05);
-
   overflow: hidden;
 }
 
@@ -102,9 +43,9 @@
   display: flex;
   flex-direction: column;
 
-  background: rgba(0, 0, 0, 0.05);
-  border-right: 1px solid rgba(0, 0, 0, 0.05);
-  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.125);
+  background: var(--color-base);
+  border-right: 1px solid rgba(var(--color-black-raw), 0.05);
+  // box-shadow: 0px 0px 5px rgba(var(--color-black-raw), 0.125);
 
   padding: 0.5rem;
 
@@ -130,6 +71,28 @@
   padding-right: 1rem;
 }
 
+.track-container-wrapper {
+  position: relative;
+
+  height: 100%;
+  width: 100%;
+
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    pointer-events: none;
+
+    box-shadow: inset 0px 0px 5px 0px rgba(var(--color-black-raw), 0.125);
+  }
+}
+
 .track-container {
   display: flex;
   align-items: baseline;
@@ -139,6 +102,8 @@
 
   padding-left: 1rem;
   padding-right: 1rem;
+
+  background: var(--color-crust);
 
   overflow-x: scroll;
   overflow-y: hidden;

--- a/src/components/daw/Interface.tsx
+++ b/src/components/daw/Interface.tsx
@@ -603,25 +603,27 @@ export function Interface(): JSX.Element {
             </button>
           </div>
 
-          <div className={styles['track-container']}>
-            {tracks.map(
-              (trackOptions: TrackOptions): JSX.Element =>
-                Object.hasOwnProperty.call(trackOptions, 'defaultKitId') ? (
-                  <Track
-                    options={trackOptions}
-                    key={trackOptions.id}
-                    channels={channels}
-                    kits={kits}
-                  />
-                ) : (
-                  <Track
-                    options={trackOptions}
-                    key={trackOptions.id}
-                    channels={channels}
-                    synths={synths}
-                  />
-                ),
-            )}
+          <div className={styles['track-container-wrapper']}>
+            <div className={styles['track-container']}>
+              {tracks.map(
+                (trackOptions: TrackOptions): JSX.Element =>
+                  Object.hasOwnProperty.call(trackOptions, 'defaultKitId') ? (
+                    <Track
+                      options={trackOptions}
+                      key={trackOptions.id}
+                      channels={channels}
+                      kits={kits}
+                    />
+                  ) : (
+                    <Track
+                      options={trackOptions}
+                      key={trackOptions.id}
+                      channels={channels}
+                      synths={synths}
+                    />
+                  ),
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/components/daw/KitList.module.scss
+++ b/src/components/daw/KitList.module.scss
@@ -1,3 +1,7 @@
+.kit-list {
+  padding-top: 1rem;
+}
+
 .kit {
   position: relative;
 
@@ -5,37 +9,13 @@
   padding-top: 0.5rem;
 
   font-size: 0.75rem;
-
-  &:nth-child(even) {
-    background: rgba(0, 0, 0, 0.05);
-  }
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-
-    background: rgba(255, 0, 0, 0.25);
-
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  &.loading::before {
-    position: absolute;
-    opacity: 1;
-    pointer-events: all;
-  }
 }
 
 .name {
   margin: 0;
   padding: 0;
 
-  color: #aaa;
+  color: var(--color-subtext0);
 }
 
 .controls {

--- a/src/components/daw/SynthList.module.scss
+++ b/src/components/daw/SynthList.module.scss
@@ -1,25 +1,22 @@
+.synth-selector {
+  display: block;
+  min-width: 50%;
+  max-width: 90%;
+  margin: 1rem auto;
+}
+
 .synth {
   padding: 1rem;
   padding-top: 0.5rem;
 
   font-size: 0.75rem;
-
-  &:nth-child(even) {
-    background: linear-gradient(
-      to bottom,
-      rgba(0, 0, 0, 0.05) 0%,
-      rgba(0, 0, 0, 0.025) 10%,
-      rgba(0, 0, 0, 0.025) 90%,
-      rgba(0, 0, 0, 0.05) 100%
-    );
-  }
 }
 
 .name {
   margin: 0;
   padding: 0;
 
-  color: #aaa;
+  color: var(--color-surface2);
 }
 
 .controls {

--- a/src/components/daw/TapBpm.module.scss
+++ b/src/components/daw/TapBpm.module.scss
@@ -5,17 +5,21 @@
   padding-top: 0;
   padding-bottom: 0;
 
+  border-left-width: 0.5px;
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+
   font-size: 0.5rem;
 
   writing-mode: vertical-lr;
   text-orientation: upright;
 
-  color: rgba(255, 255, 255, 0.3);
+  color: var(--color-text);
 
   transition-timing-function: ease-in-out;
 
   &.pulse,
   &:active {
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--color-subtext0);
   }
 }

--- a/src/components/daw/Track.module.scss
+++ b/src/components/daw/Track.module.scss
@@ -10,18 +10,14 @@
 
   margin: 0.5rem;
 
-  border: 1px solid rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(var(--color-black-raw), 0.25);
   border-radius: 10px;
 
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.125);
+  box-shadow: 0px 0px 10px rgba(var(--color-black-raw), 0.125);
 
   overflow-y: scroll;
 
-  background: rgba(0, 0, 0, 0.025);
-
-  &:nth-child(even) {
-    background: rgba(0, 0, 0, 0.05);
-  }
+  background: var(--color-base);
 }
 
 .info {
@@ -39,12 +35,6 @@
   label {
     width: 100%;
     margin: 0.125rem 0;
-
-    input,
-    select {
-      border: 1px solid rgba(0, 0, 0, 0.05);
-      border-radius: 10px;
-    }
   }
 }
 

--- a/src/components/daw/shared.module.scss
+++ b/src/components/daw/shared.module.scss
@@ -18,14 +18,6 @@
     input,
     select {
       margin-left: 0.25rem;
-
-      border: 1px solid #0e0e11;
-
-      &:not(:focus-visible).beats,
-      &:not(:focus-visible).repeats {
-        border-top: 1px solid transparent;
-        border-bottom: 1px solid transparent;
-      }
     }
   }
 }

--- a/src/components/debug/ErrorBoundry.module.scss
+++ b/src/components/debug/ErrorBoundry.module.scss
@@ -140,11 +140,11 @@
   font-size: 1.5rem;
   font-weight: 700;
 
-  color: #ffaaaa;
+  color: var(--color-rosewater);
 }
 
 .message {
-  color: #fff;
+  color: var(--color-white);
 }
 
 .stack {

--- a/src/components/decorative/Alic3.module.scss
+++ b/src/components/decorative/Alic3.module.scss
@@ -43,7 +43,7 @@
   &:focus,
   &:hover {
     text-decoration: none;
-    color: #eaefff;
+    color: var(--color-text);
   }
 
   &:hover,

--- a/src/components/decorative/Eye.module.scss
+++ b/src/components/decorative/Eye.module.scss
@@ -24,4 +24,19 @@
   transform: skew(0, 0) scale(1, 1);
 
   animation: breathe 24s ease-in-out 0s infinite alternate;
+
+  &.full {
+    position: fixed;
+    top: 0;
+    left: 0;
+
+    width: 100vw;
+    max-width: unset;
+    height: 100vh;
+    max-height: unset;
+
+    transform: none;
+
+    animation: none;
+  }
 }

--- a/src/components/layout/Dialogs/Dialog.module.scss
+++ b/src/components/layout/Dialogs/Dialog.module.scss
@@ -10,17 +10,9 @@
 
   padding: 2rem;
 
-  // background: #333;
-  background: radial-gradient(
-    farthest-corner at 0% 100%,
-    #1c1b28 0%,
-    #1c1b24 20%,
-    #1b1b22 33%,
-    #1c1b24 50%,
-    #1c1b25 100%
-  );
+  background: var(--color-base);
 
-  box-shadow: 3px 3px 5px 2px rgba(0, 0, 0, 0.25);
+  box-shadow: 3px 3px 5px 2px rgba(var(--color-black-raw), 0.25);
 
   border-radius: 0px;
 

--- a/src/components/layout/Dialogs/DialogContainer.module.scss
+++ b/src/components/layout/Dialogs/DialogContainer.module.scss
@@ -5,7 +5,7 @@
   right: 0;
   bottom: 0;
 
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(var(--color-overlay2-raw), 0.3);
 
   pointer-events: none;
 

--- a/src/components/layout/Dialogs/DialogHeader.module.scss
+++ b/src/components/layout/Dialogs/DialogHeader.module.scss
@@ -10,10 +10,5 @@
 
   padding: 1rem 2rem;
 
-  // background: rgba(0, 0, 0, 0.1);
-  background: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0.0125),
-    rgba(0, 0, 0, 0.1)
-  );
+  background: var(--color-mantle);
 }

--- a/src/components/layout/Tabbed.module.scss
+++ b/src/components/layout/Tabbed.module.scss
@@ -4,36 +4,42 @@
 
   height: 100%;
 
-  background: linear-gradient(
-    to right,
-    rgba(0, 0, 0, 0.025) 0%,
-    rgba(0, 0, 0, 0.0125) 100%
-  );
+  background: var(--color-base);
 }
 
 .switcher {
   display: flex;
 
-  background: linear-gradient(to top, #191920, #1b1b22);
+  padding-top: 2px;
 }
 
 button.header {
-  padding: 0.25rem 2rem;
+  padding: 0.375rem 2rem;
 
-  background-color: rgba(0, 0, 0, 0.1);
+  background: var(--color-mantle);
+  color: var(--color-subtext0);
 
   border: none;
+  border-radius: 0px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+
+  box-shadow: inset 0px -2px 2px rgba(29, 28, 28, 0.025);
 
   white-space: nowrap;
 
   cursor: pointer;
 
+  transition: box-shadow 100ms ease-in-out, color 100ms ease-in-out,
+    background 100ms ease-in-out;
+
   &.active {
-    background-color: #1b1b22;
+    background: var(--color-base);
+    box-shadow: none;
 
     cursor: unset;
 
-    color: #ddd;
+    color: var(--color-text);
   }
 
   &:first-of-type {
@@ -42,22 +48,23 @@ button.header {
 
   &:active,
   &:hover {
-    box-shadow: none;
+    box-shadow: inset 0px -1px 1px rgba(0, 0, 0, 0.025);
 
     &:not(.active) {
-      background-color: rgba(0, 0, 0, 0.125);
-
-      transition: background-color 100ms ease-in-out;
+      background: var(--color-mantle);
+      color: var(--color-text);
     }
   }
 }
 
 .tab {
-  display: none;
+  height: 0px;
+  visibility: hidden;
 
   overflow-y: auto;
 
   &.active {
-    display: unset;
+    height: unset;
+    visibility: unset;
   }
 }

--- a/src/components/modules/EyeGen.module.scss
+++ b/src/components/modules/EyeGen.module.scss
@@ -33,8 +33,8 @@
 
   writing-mode: vertical-rl;
 
-  color: var(--color-black);
-  text-shadow: 0.25em 2em rgba(var(--color-primary-red-raw), 0.4);
+  color: var(--color-text);
+  text-shadow: 0.25em 2em rgba(var(--color-red-raw), 0.4);
   opacity: 0.25;
 
   overflow: hidden;

--- a/src/components/modules/EyeGen.module.scss
+++ b/src/components/modules/EyeGen.module.scss
@@ -9,10 +9,12 @@
   font-family: 'ヒラギノ角ゴ Pro W3', 'Hiragino Kaku Gothic Pro', Osaka,
     'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', 'MS PGothic', sans-serif;
 
-  // background-color: #1d1d1d;
-
   & input[type='number'] {
     width: 48px;
+  }
+
+  &.full {
+    background: var(--color-black);
   }
 }
 
@@ -31,8 +33,8 @@
 
   writing-mode: vertical-rl;
 
-  color: #000;
-  text-shadow: 0.25em 2em rgba(255, 0, 0, 0.4);
+  color: var(--color-black);
+  text-shadow: 0.25em 2em rgba(var(--color-primary-red-raw), 0.4);
   opacity: 0.25;
 
   overflow: hidden;
@@ -49,6 +51,15 @@
   transform: translateX(-50%);
 
   z-index: -2;
+
+  &.full {
+    position: unset;
+    top: unset;
+    left: unset;
+    transform: unset;
+
+    z-index: unset;
+  }
 }
 
 .controls {

--- a/src/contexts/ColorSchemeContext.tsx
+++ b/src/contexts/ColorSchemeContext.tsx
@@ -1,0 +1,80 @@
+import type { AlphaColor, Color, Labels, Variants } from '@catppuccin/palette'
+
+import React from 'react'
+
+import palette from '@catppuccin/palette'
+
+export type ColorScheme = Labels<string, string>
+
+interface IntermediaryColorSchemeExtraction {
+  label: string
+  hex: string
+}
+
+const defaultColorScheme: ColorScheme = Object.keys(palette.variants.latte)
+  .map((label: string): IntermediaryColorSchemeExtraction => {
+    return {
+      label,
+      hex: palette.variants.latte[label as keyof Labels<Color, AlphaColor>].hex,
+    }
+  })
+  .reduce<Partial<ColorScheme>>(
+    (
+      prev: Partial<ColorScheme>,
+      cur: IntermediaryColorSchemeExtraction,
+    ): Partial<ColorScheme> => {
+      prev[cur.label as keyof Labels<Color, AlphaColor>] = cur.hex
+
+      return prev
+    },
+    {},
+  ) as ColorScheme
+
+export const ColorSchemeContext =
+  React.createContext<ColorScheme>(defaultColorScheme)
+
+function generateColorScheme(): ColorScheme {
+  const styles: CSSStyleDeclaration = window.getComputedStyle(
+    document.documentElement,
+  )
+
+  const colorScheme: ColorScheme = { ...defaultColorScheme }
+
+  for (const label in palette.labels) {
+    colorScheme[label as keyof Labels<Variants<Color>, Variants<Color>>] =
+      styles.getPropertyValue(`--color-${label}`)
+  }
+
+  return colorScheme
+}
+
+export function ColorSchemeProvider({
+  children,
+}: React.PropsWithChildren): React.ReactNode {
+  const [colorScheme, setColorScheme] =
+    React.useState<ColorScheme>(generateColorScheme)
+
+  React.useEffect((): void | (() => void) => {
+    if (!window.matchMedia) return
+
+    const onColorSchemeChange = (): void => {
+      setColorScheme(generateColorScheme())
+    }
+
+    window
+      .matchMedia('(prefers-color-scheme: light)')
+      .addEventListener('change', onColorSchemeChange)
+
+    return (): void => {
+      window
+        .matchMedia('(prefers-color-scheme: light)')
+        .removeEventListener('change', onColorSchemeChange)
+    }
+  }, [])
+
+  return (
+    <ColorSchemeContext.Provider value={colorScheme}>
+      {children}
+    </ColorSchemeContext.Provider>
+  )
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,18 +1,91 @@
 @import url('https://fonts.googleapis.com/css2?family=Major+Mono+Display&display=swap');
 
+@import '@catppuccin/palette/style';
+
+@mixin set-color($flavor, $color) {
+  --color-#{$color}: var(--ctp-#{$flavor}-#{$color});
+  --color-#{$color}-rgb: var(--ctp-#{$flavor}-#{$color}-rgb);
+  --color-#{$color}-hsl: var(--ctp-#{$flavor}-#{$color}-hsl);
+  --color-#{$color}-raw: var(--ctp-#{$flavor}-#{$color}-raw);
+}
+
+@mixin set-flavor-colors($flavor) {
+  @include set-color($flavor, 'rosewater');
+  @include set-color($flavor, 'flamingo');
+  @include set-color($flavor, 'pink');
+  @include set-color($flavor, 'mauve');
+  @include set-color($flavor, 'red');
+  @include set-color($flavor, 'maroon');
+  @include set-color($flavor, 'peach');
+  @include set-color($flavor, 'yellow');
+  @include set-color($flavor, 'green');
+  @include set-color($flavor, 'teal');
+  @include set-color($flavor, 'sky');
+  @include set-color($flavor, 'sapphire');
+  @include set-color($flavor, 'blue');
+  @include set-color($flavor, 'lavender');
+  @include set-color($flavor, 'text');
+  @include set-color($flavor, 'subtext1');
+  @include set-color($flavor, 'subtext0');
+  @include set-color($flavor, 'overlay2');
+  @include set-color($flavor, 'overlay1');
+  @include set-color($flavor, 'overlay0');
+  @include set-color($flavor, 'surface2');
+  @include set-color($flavor, 'surface1');
+  @include set-color($flavor, 'surface0');
+  @include set-color($flavor, 'crust');
+  @include set-color($flavor, 'mantle');
+  @include set-color($flavor, 'base');
+}
+
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+  --color-white: #ffffff;
+  --color-white-rgb: rgb(255, 255, 255);
+  --color-white-hsl: hsl(0, 0%, 100%);
+  --color-white-raw: 255, 255, 255;
 
-  color-scheme: light dark;
-  color: #dedede;
-  background-color: #242424;
+  --color-black: #000000;
+  --color-black-rgb: rgb(0, 0, 0);
+  --color-black-hsl: hsl(0, 0%, 0%);
+  --color-black-raw: 0, 0, 0;
 
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  --color-primary-red: #ff0000;
+  --color-primary-red-rgb: rgb(255, 0, 0);
+  --color-primary-red-hsl: hsl(0, 100%, 50%);
+  --color-primary-red-raw: 255, 0, 0;
+
+  --color-primary-green: #00ff00;
+  --color-primary-green-rgb: rgb(0, 255, 0);
+  --color-primary-green-hsl: hsl(120, 100%, 50%);
+  --color-primary-green-raw: 0, 255, 0;
+
+  --color-primary-blue: #0000ff;
+  --color-primary-blue-rgb: rgb(0, 0, 255);
+  --color-primary-blue-hsl: hsl(240, 100%, 50%);
+  --color-primary-blue-raw: 0, 0, 255;
+
+  @media (prefers-color-scheme: light) {
+    @include set-flavor-colors('latte');
+  }
+
+  @media (prefers-color-scheme: dark) {
+    @include set-flavor-colors('frappe');
+  }
+
+  & {
+    font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+    line-height: 1.5;
+    font-weight: 400;
+
+    color-scheme: light dark;
+    color: var(--color-text);
+    background-color: var(--color-base);
+
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 }
 
 body {
@@ -33,10 +106,14 @@ body {
   box-sizing: border-box;
 }
 
+a {
+  color: var(--color-blue);
+}
+
 label {
   text-align: center;
 
-  color: #666;
+  color: var(--color-subtext0);
 
   font-size: 16px;
 
@@ -49,23 +126,22 @@ input {
   min-width: 100px;
   padding: 6px;
 
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--color-base);
 
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--color-crust);
   border-radius: 6px;
 
-  color: #aaa;
+  color: var(--color-text);
 
-  transition: color 250ms ease-in-out, box-shadow 250ms ease-in-out;
+  transition: box-shadow 100ms ease-in-out;
 
   &:hover,
   &:focus-visible {
-    color: #ccc;
-    box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.125);
+    box-shadow: 0px 1px 4px 0px rgba(var(--color-black-raw), 0.05);
   }
 
   &:focus-visible {
-    outline: 1px solid rgba(255, 0, 0, 0.6);
+    outline: 1px solid rgba(var(--color-blue-raw), 0.6);
   }
 }
 
@@ -80,5 +156,5 @@ p.small {
 
   font-size: 0.75rem;
 
-  color: rgba(255, 255, 255, 0.3);
+  color: var(--color-subtext0);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,8 @@ import { ErrorBoundary } from './components/debug/ErrorBoundry'
 
 import './index.scss'
 
+import { ColorSchemeProvider } from './contexts/ColorSchemeContext'
+
 const getTitleLoader = (title: string): LoaderFunction => {
   return (): null => {
     document.title = title
@@ -32,7 +34,9 @@ const getTitleLoader = (title: string): LoaderFunction => {
 }
 
 const withErrorBoundary = (app: JSX.Element, appName?: string): JSX.Element => (
-  <ErrorBoundary app={appName}>{app}</ErrorBoundary>
+  <ErrorBoundary app={appName}>
+    <ColorSchemeProvider>{app}</ColorSchemeProvider>
+  </ErrorBoundary>
 )
 
 const router = createBrowserRouter(


### PR DESCRIPTION
Adds support for light and dark color schemes.
Implemented with [Catppuccin](https://github.com/catppuccin/catppuccin).

<img width="1810" alt="スクリーンショット 2024-07-11 午後8 22 17" src="https://github.com/user-attachments/assets/cc1e5c5a-5399-4de1-93c9-ea5a10e74881">
<img width="1810" alt="スクリーンショット 2024-07-11 午後8 25 24" src="https://github.com/user-attachments/assets/5ec05341-bd0c-41f6-b7f8-999ff625f155">
